### PR TITLE
Fix silent failure when socket name doesn't contain at least 2 spaces

### DIFF
--- a/src/main/java/uk/me/hardill/TRADFRI2MQTT/Main.java
+++ b/src/main/java/uk/me/hardill/TRADFRI2MQTT/Main.java
@@ -366,7 +366,10 @@ public class Main {
 						if (json.has(TYPE) && json.getInt(TYPE) == TYPE_BULB && json.has(LIGHT)) { // single bulb
 							String socket = "";
 							try {
-								socket = " " + json.getJSONObject("3").getString("1").split(" ")[2];
+								socket = " " + json.getJSONObject("3").getString("1");
+								if (socket.startsWith(" TRADFRI bulb ")) {
+									socket = " " + socket.split(" ")[3];
+								}
 							} catch (JSONException e) {}
 							System.out.println("Processing" + socket + " Bulb " + name + " " + response.getResponseText());
 


### PR DESCRIPTION
Philips Hue lights identify their model with a simple string like `LWB004` or `LWB010`, this causes the code
```java
socket = " " + json.getJSONObject("3").getString("1").split(" ")[2];
```
to throw a silent `ArrayIndexOutOfBoundsException`

JSON response for my Hue light:
```json
{
  "9001":"Living room",
  "9002":1498931354,
  "9020":1499042697,
  "9003":65548,
  "9054":0,
  "5750":2,
  "9019":1,
  "3": {"0":"Philips", "1":"LWB004", "2":"", "3":"5.38.2.19136", "6":1},
  "3311":[{"5850":0,"5851":153,"9003":0}]
}
```

The patch modifies the above line to first check if the model starts with "TRADFRI bulb" before doing a split